### PR TITLE
Configuration and event updates

### DIFF
--- a/src/grid-bots/multi-vendor-multi-contract.py
+++ b/src/grid-bots/multi-vendor-multi-contract.py
@@ -1,4 +1,4 @@
-# 2023-09-27 14:25:01
+# 2023-09-28 12:39:26
 # Note: this file is to be used within profitview.net/trading/bots
 # pylint: disable=locally-disabled, import-self, import-error, missing-class-docstring, invalid-name, consider-using-dict-items
 
@@ -234,12 +234,13 @@ class Trading(Link):
         tob_bid, tob_ask =  self.VENUES[venue][sym]['tob']
         if(np.isnan(tob_bid) or np.isnan(tob_ask)):
           continue
-        intent = self.orders_intent(self.VENUES[venue][sym])
-        bids = intent['bids']
-        asks = intent['asks']
 
         #cancel all current orders
         self.cancel_order(venue, sym=sym)
+
+        intent = self.orders_intent(self.VENUES[venue][sym])
+        bids = intent['bids']
+        asks = intent['asks']
 
         # Buy orders
         if (abs(self.VENUES[venue][sym]['current_risk']) <  self.VENUES[venue][sym]['max_risk']) or (self.VENUES[venue][sym]['current_risk'] <= 0):

--- a/src/grid-bots/multi-vendor-multi-contract.py
+++ b/src/grid-bots/multi-vendor-multi-contract.py
@@ -1,9 +1,10 @@
-# 2023-09-30 22:36:10
+# 2023-10-01 18:23:09
 # Note: this file is to be used within profitview.net/trading/bots
 # pylint: disable=locally-disabled, import-self, import-error, missing-class-docstring, invalid-name, consider-using-dict-items, broad-except
 
 import asyncio
 import json
+import threading
 import time
 
 from profitview import Link, http, logger
@@ -25,6 +26,28 @@ OMEGA = 1.605025e-08
 ALPHA = 0.193613
 BETA = 0.786155
 
+def debounce(wait):
+  """Postpone a function execution until after wait seconds
+  have elapsed since the last time it was invoked.
+  source: https://gist.github.com/walkermatt/2871026"""
+  def decorator(func):
+    def debounced(*args, **kwargs):
+      def call_func():
+        debounced.last_call = time.time()
+        func(*args, **kwargs)
+
+      if hasattr(debounced, 'timer'):
+        debounced.timer.cancel()
+
+      if time.time() - getattr(debounced, 'last_call', 0) > wait:
+        call_func()
+      else:
+        debounced.timer = threading.Timer(wait, call_func)
+        debounced.timer.start()
+
+    return debounced
+  return decorator
+
 class Trading(Link):
   ACTIVE = True
   UPDATE_SECONDS = 60
@@ -42,17 +65,23 @@ class Trading(Link):
           'order_size': 1_000 * 400,
           'max_risk': 1_000 * 400 * 10,                  # Means max 10 times the base order size
           'price_precision': 0.5,
+          'price_spread': 0.5,
           'size_precision': 1_000,
           'direction': 'FLAT',
           'multiplier': 1,
+          'mode' : 'GRID', # 'TOB'
+          'tob_is_bid' : False,
         },
         'XBTUSD' : {
           'order_size': 100 * 5,
           'max_risk': 100 * 5 * 160,
           'price_precision': 0.5,
+          'price_spread': 0.5 * 5,
           'size_precision': 100,
           'direction': 'FLAT',
           'multiplier': 1,
+          'mode' : 'GRID',
+          'tob_is_bid' : True,
         },
         'ETHUSD' : {
           'order_size': 20,
@@ -106,6 +135,7 @@ class Trading(Link):
         },
       }
     }
+  INIT_COMPLETE = False
 
   def __init__(self):
     super().__init__()
@@ -125,11 +155,15 @@ class Trading(Link):
         self.VENUES[venue][sym]['macd'] = {'hist':np.nan, 'slope':np.nan}
         self.VENUES[venue][sym]['price_decimals'] = str(self.VENUES[venue][sym]['price_precision'])[::-1].find('.')
         self.VENUES[venue][sym]['size_precision'] = self.VENUES[venue][sym].get('size_precision', 1_000)
+        self.VENUES[venue][sym]['price_spread'] = self.VENUES[venue][sym].get('price_spread', 0.5)
+        self.VENUES[venue][sym]['mode'] = self.VENUES[venue][sym].get('mode', 'GRID')
+        self.VENUES[venue][sym]['tob_is_bid'] = self.VENUES[venue][sym].get('tob_is_bid', True)
 
         candles = self.fetch_candles(self.MAIN_VENUE, sym, level=self.LEVEL)
         self.VENUES[venue][sym]['candles'] = {x['time']: x['close'] for x in candles['data']} | self.VENUES[venue][sym]['candles']
 
     self.fetch_current_risk()
+    self.INIT_COMPLETE = True
     asyncio.run(self.minutely_update())
 
   def hypo_rsi(self, closes, ret):
@@ -183,31 +217,33 @@ class Trading(Link):
     return np.round(tick * np.round(x / tick), decimals)
 
   def orders_intent(self, sym):
-    tob_bid, tob_ask = sym['tob']
-    times, closes = zip(*sorted(sym['candles'].items())[-self.LOOKBACK:])
-    if len(sym['candles']) > 10 * self.LOOKBACK :
-      sym['candles'] = dict(zip(times, closes))
-    closes = list(filter(None,closes))
-    X = np.linspace(-0.2, 0.2, self.LOOKBACK)
-    Y = [self.hypo_rsi(closes, x) for x in X]
-    func = interp1d(Y, X, kind='cubic', fill_value='extrapolate')
-    #logger.info(json.dumps({
-    #  'sym': sym['sym'],
-    #  'total': 0.5 * round(closes[-1] * (1 + float(func(60))) / 0.5),
-    #  'close': closes[-1],
-    #  'closeLength': len(closes),
-    #  'func': (1 + float(func(60))),
-    #  'tob': tob_ask,
-    #  'final_closest_bid': np.max([tob_ask, 0.5 * round(closes[-1] * (1 + float(func(60))) / 0.5)]),
-    #  'current_risk': sym['current_risk']
-    #}))
+    orders = {'bids': {}, 'asks': {}}
+    if sym['mode'] == 'GRID' :
+      tob_bid, tob_ask = sym['tob']
+      times, closes = zip(*sorted(sym['candles'].items())[-self.LOOKBACK:])
+      if len(sym['candles']) > 10 * self.LOOKBACK :
+        sym['candles'] = dict(zip(times, closes))
+      closes = list(filter(None,closes))
+      X = np.linspace(-0.2, 0.2, self.LOOKBACK)
+      Y = [self.hypo_rsi(closes, x) for x in X]
+      func = interp1d(Y, X, kind='cubic', fill_value='extrapolate')
+      #logger.info(json.dumps({
+      #  'sym': sym['sym'],
+      #  'total': 0.5 * round(closes[-1] * (1 + float(func(60))) / 0.5),
+      #  'close': closes[-1],
+      #  'closeLength': len(closes),
+      #  'func': (1 + float(func(60))),
+      #  'tob': tob_ask,
+      #  'final_closest_bid': np.max([tob_ask, 0.5 * round(closes[-1] * (1 + float(func(60))) / 0.5)]),
+      #  'current_risk': sym['current_risk']
+      #}))
 
-    orders = {
-      'bids': [np.min([tob_bid, self.round_value(0.5 * round(closes[-1] * (1 + float(func(x))) / 0.5,4),sym['price_precision'], sym['price_decimals'])]) for x in self.GRID_BIDS],
-      'asks': [np.max([tob_ask, self.round_value(0.5 * round(closes[-1] * (1 + float(func(x))) / 0.5,4),sym['price_precision'], sym['price_decimals'])]) for x in self.GRID_ASKS]
-    }
-    orders['bids'] = self.remove_duplicates(orders['bids'])
-    orders['asks'] = self.remove_duplicates(orders['asks'])
+      orders = {
+        'bids': [np.min([tob_bid, self.round_value(0.5 * round(closes[-1] * (1 + float(func(x))) / 0.5,4),sym['price_precision'], sym['price_decimals'])]) for x in self.GRID_BIDS],
+        'asks': [np.max([tob_ask, self.round_value(0.5 * round(closes[-1] * (1 + float(func(x))) / 0.5,4),sym['price_precision'], sym['price_decimals'])]) for x in self.GRID_ASKS]
+      }
+      orders['bids'] = self.remove_duplicates(orders['bids'])
+      orders['asks'] = self.remove_duplicates(orders['asks'])
 
     logger.info('sym:' + sym['sym'] + json.dumps(orders))
     return orders
@@ -242,24 +278,34 @@ class Trading(Link):
           price = tob
           execInst = 'Close'
 
-        try:
-          if self.ACTIVE:
-            self.call_endpoint(
-              venue,
-              'order',
-              'private',
-              method = 'POST',
-              params = {
-                'symbol': sym['sym'],
-                'side': side,
-                'price': price,
-                'ordType': 'Limit',
-                'execInst': execInst,
-                'text': 'Sent from ProfitView.net'
-              }
-            )
-        except Exception as e:
-          logger.error(f"POST order {e}")
+        for attempt in range(10):
+          try:
+            if self.ACTIVE:
+              response = self.call_endpoint(
+                venue,
+                'order',
+                'private',
+                method = 'POST',
+                params = {
+                  'symbol': sym['sym'],
+                  'side': side,
+                  'price': price,
+                  'ordType': 'Limit',
+                  'execInst': execInst,
+                  'text': 'Sent from ProfitView.net'
+                }
+              )
+              if response["error"] is not None :
+                logger.error(f"POST order {response['error']}")
+                time.sleep(0.1)
+                continue
+              if attempt > 0 :
+                logger.info(f"POST order success after {attempt=}")
+          except Exception as e:
+            logger.error(f"POST order {e}")
+            time.sleep(0.1)
+          else:
+            break
 
       else :
         # If there is a current open position in the opposite direction, multiply the order size
@@ -306,23 +352,34 @@ class Trading(Link):
               # Use an order, and remove from list of available at same time
               order_id, _ = orders.popitem()
               # Amend the order
-              try:
-                if self.ACTIVE:
-                  self.call_endpoint(
-                    venue,
-                    'order',
-                    'private',
-                    method = 'PUT',
-                    params = {
-                      'orderID': order_id,
-                      'price': price,
-                      'text': 'Sent from ProfitView.net'
-                    }
-                  )
-              except Exception as e:
-                logger.error(f"PUT order {e}")
-              # Price used, we don't need it in next cycles
-              prices.remove(price)
+              for attempt in range(10):
+                try:
+                  if self.ACTIVE:
+                    response = self.call_endpoint(
+                      venue,
+                      'order',
+                      'private',
+                      method = 'PUT',
+                      params = {
+                        'orderID': order_id,
+                        'price': price,
+                        'text': 'Sent from ProfitView.net'
+                      }
+                    )
+                    if response["error"] is not None :
+                      logger.error(f"PUT order {response['error']}")
+                      time.sleep(0.1)
+                      continue
+                    if attempt > 0 :
+                      logger.info(f"PUT order success after {attempt=}")
+                  prices.remove(price)
+                except Exception as e:
+                  if 'Filled' in str(e):
+                    break
+                  logger.error(f"PUT order {e}")
+                  time.sleep(0.1)
+                else:
+                  break
             else :
               break
 
@@ -334,45 +391,67 @@ class Trading(Link):
             if reduce_only :
               if (sign * int(reduce_size + sign * sym['order_size'] * multiplier)) > 0 :
                 break
-            try:
-              if self.ACTIVE:
-                self.call_endpoint(
-                  venue,
-                  'order',
-                  'private',
-                  method = 'POST',
-                  params = {
-                    'symbol': sym['sym'],
-                    'side': side,
-                    'orderQty': sym['order_size'] * multiplier,
-                    'price': price,
-                    'ordType': 'Limit',
-                    'execInst': execInst,
-                    'text': 'Sent from ProfitView.net'
-                  }
-                )
-              reduce_size = round(reduce_size + sign * sym['order_size'] * multiplier, 1)
-            except Exception as e:
-              logger.error(f"POST order {e}")
+            for attempt in range(10):
+              try:
+                if self.ACTIVE:
+                  response = self.call_endpoint(
+                    venue,
+                    'order',
+                    'private',
+                    method = 'POST',
+                    params = {
+                      'symbol': sym['sym'],
+                      'side': side,
+                      'orderQty': sym['order_size'] * multiplier,
+                      'price': price,
+                      'ordType': 'Limit',
+                      'execInst': execInst,
+                      'text': 'Sent from ProfitView.net'
+                    }
+                  )
+                  if response["error"] is not None :
+                    logger.error(f"POST order {response['error']}")
+                    time.sleep(0.1)
+                    continue
+                  if attempt > 0 :
+                    logger.info(f"POST order success after {attempt=}")
+                reduce_size = round(reduce_size + sign * sym['order_size'] * multiplier, 1)
+              except Exception as e:
+                logger.error(f"POST order {e}")
+                time.sleep(0.1)
+              else:
+                break
+
+        # TODO calculate open orders + current_risk and cancel orders that would let go above max_risk
 
         # There are more orders left but no prices, cancel the orders
         if orders :
           for order_id, _ in orders.items() :
             # Cancel the order
-            try:
-              if self.ACTIVE:
-                self.call_endpoint(
-                  venue,
-                  'order',
-                  'private',
-                  method='DELETE',
-                  params={
-                    'orderID': order_id,
-                    'text': 'Sent from ProfitView.net'
-                  }
-                )
-            except Exception as e:
-              logger.error(f"DELETE order {e}")
+            for attempt in range(10):
+              try:
+                if self.ACTIVE:
+                  response = self.call_endpoint(
+                    venue,
+                    'order',
+                    'private',
+                    method='DELETE',
+                    params={
+                      'orderID': order_id,
+                      'text': 'Sent from ProfitView.net'
+                    }
+                  )
+                  if response["error"] is not None :
+                    logger.error(f"DELETE order {response['error']}")
+                    time.sleep(0.1)
+                    continue
+                  if attempt > 0 :
+                    logger.info(f"DELETE order success after {attempt=}")
+              except Exception as e:
+                logger.error(f"DELETE order {e}")
+                time.sleep(0.1)
+              else:
+                break
 
   async def update_limit_orders(self):
     for venue in self.VENUES:
@@ -382,30 +461,75 @@ class Trading(Link):
         if(np.isnan(tob_bid) or np.isnan(tob_ask)):
           continue
 
-        intent = self.orders_intent(self.VENUES[venue][sym])
+        wait = True
+        if self.VENUES[venue][sym]['mode'] == 'GRID' :
+          intent = self.orders_intent(self.VENUES[venue][sym])
 
-        # Buy orders
-        self.place_orders(is_bid=True, venue=venue, sym=self.VENUES[venue][sym], tob=tob_bid, prices=intent['bids'] )
-        # Sell orders
-        self.place_orders(is_bid=False, venue=venue, sym=self.VENUES[venue][sym], tob=tob_ask, prices=intent['asks'] )
+          # Buy orders
+          self.place_orders(is_bid=True, venue=venue, sym=self.VENUES[venue][sym], tob=tob_bid, prices=intent['bids'] )
+          # Sell orders
+          self.place_orders(is_bid=False, venue=venue, sym=self.VENUES[venue][sym], tob=tob_ask, prices=intent['asks'] )
+        else :
+          wait = False
 
-        await asyncio.sleep(1)
+        if wait :
+          await asyncio.sleep(1)
+
+  @debounce(1)
+  def update_tob_order(self, venue, sym) :
+    tob_bid, tob_ask = sym['tob']
+
+    # We expect 1 order only to exist, verify if it is bid or ask
+    if sym['tob_is_bid'] :
+      tob = tob_bid - sym['price_spread']
+    else :
+      tob = tob_ask + sym['price_spread']
+
+    logger.info(f'sym: {sym["sym"]} Update tob, {tob=} is_bid={sym["tob_is_bid"]}')
+
+    # Create or update the order with the right side and tob value
+    self.place_orders(is_bid=sym['tob_is_bid'], venue=venue, sym=sym, tob=tob, prices=[tob] )
+
+  def reverse_tob_order(self, venue, sym) :
+    tob_bid, tob_ask = sym['tob']
+
+    sym['tob_is_bid'] = not sym['tob_is_bid']
+
+    if sym['tob_is_bid'] :
+      tob = tob_bid - ( sym['price_precision'] * 10 )
+    else :
+      tob = tob_ask + ( sym['price_precision'] * 10 )
+
+    logger.info(f'sym: {sym["sym"]} Reverse tob, {tob=} is_bid={sym["tob_is_bid"]}')
+
+    # Create or update the order with the right side and tob value
+    self.place_orders(is_bid=sym['tob_is_bid'], venue=venue, sym=sym, tob=tob, prices=[tob] )
 
   def trade_update(self, src, sym, data):
+    if not self.INIT_COMPLETE :
+      return
     for venue in self.VENUES:
       if sym in self.VENUES[venue]:
         self.VENUES[venue][sym]['candles'][self.candle_bin(data['time'], self.LEVEL)] = data['price']
         # self.update_signal()
 
   def quote_update(self, src, sym, data):
+    if not self.INIT_COMPLETE :
+      return
     for venue in self.VENUES:
       if sym in self.VENUES[venue]:
+        tob_bid, tob_ask = self.VENUES[venue][sym]['tob']
         self.VENUES[venue][sym]['tob'] = (data['bid'][0], data['ask'][0])
         if (mid := np.mean(self.VENUES[venue][sym]['tob'])) != self.VENUES[venue][sym]['mid']:
-            self.VENUES[venue][sym]['mid'] = mid
-            # self.update_limit_orders()
+          self.VENUES[venue][sym]['mid'] = mid
+          # self.update_limit_orders()
+        if self.VENUES[venue][sym]['mode'] == 'TOB' :
+          if (tob_bid != data['bid'][0]) or (tob_ask != data['ask'][0]) :
+            self.update_tob_order(venue=venue, sym=self.VENUES[venue][sym])
 
   def order_update(self, src, sym, data):
+    if not self.INIT_COMPLETE :
+      return
     venue = data['venue']
     key = 'bid' if data['side'] == 'Buy' else 'ask'
     if venue in self.VENUES :
@@ -415,6 +539,10 @@ class Trading(Link):
           # Completed/Cancelled
           if data.get('remain_size') == 0 :
             self.VENUES[venue][sym]['orders'][key].pop(data['order_id'], None)
+            # Handle tob mode
+            if self.VENUES[venue][sym]['mode'] == 'TOB' :
+              # Handle inversion: place bid if order was Sell, place ask if order was Buy
+              self.reverse_tob_order(venue=venue, sym=self.VENUES[venue][sym])
           # Update
           else :
             self.VENUES[venue][sym]['orders'][key][data['order_id']].update(data)
@@ -425,6 +553,8 @@ class Trading(Link):
             self.VENUES[venue][sym]['orders'][key][data['order_id']] = data
 
   def fill_update(self, src, sym, data):
+    if not self.INIT_COMPLETE :
+      return
     venue = data['venue']
     sign = 1 if data['side'] == 'Buy' else -1
     if venue in self.VENUES :

--- a/src/grid-bots/multi-vendor-multi-contract.py
+++ b/src/grid-bots/multi-vendor-multi-contract.py
@@ -1,4 +1,4 @@
-# 2023-09-30 22:32:07
+# 2023-09-30 22:36:10
 # Note: this file is to be used within profitview.net/trading/bots
 # pylint: disable=locally-disabled, import-self, import-error, missing-class-docstring, invalid-name, consider-using-dict-items, broad-except
 
@@ -16,7 +16,6 @@ from talib import RSI, MACD
 TIME_LOOKUP = {
   '1m':  60_000,
   '5m' : 60_000 * 5,
-  '15m': 60_000 * 15,
   '1h':  60_000 * 60,
   '1d':  60_000 * 60 * 24,
 }

--- a/src/grid-bots/multi-vendor-multi-contract.py
+++ b/src/grid-bots/multi-vendor-multi-contract.py
@@ -1,4 +1,4 @@
-# 2023-09-28 12:39:26
+# 2023-09-28 12:57:28
 # Note: this file is to be used within profitview.net/trading/bots
 # pylint: disable=locally-disabled, import-self, import-error, missing-class-docstring, invalid-name, consider-using-dict-items
 
@@ -16,7 +16,6 @@ import time
 
 class Trading(Link):
   UPDATE_SECONDS = 60
-  MULTIPLIER = 1
   SHUT_IT_DOWN = False
   GRACEFUL_SHUTDOWN = True
   GRID_BIDS = (40, 30, 20)
@@ -33,7 +32,8 @@ class Trading(Link):
           'current_risk': 0,
           'price_precision': 0.5,
           'price_decimals': 1,
-          'direction': 'FLAT'
+          'direction': 'FLAT',
+          'multiplier': '1',
         },
         'XBTUSD' : {
           'sym': 'XBTUSD',
@@ -271,7 +271,7 @@ class Trading(Link):
             # If I have a current open position in the opposite direction, double the order size
             multiplier = 1
             if(self.VENUES[venue][sym]['current_risk'] <= 0):
-              multiplier = self.MULTIPLIER
+              multiplier = self.VENUES[venue][sym].get('multiplier', 1)
             if(self.VENUES[venue][sym]['direction'] == 'SHORT'):
               execInst = 'ParticipateDoNotInitiate,ReduceOnly'
             else:
@@ -325,7 +325,7 @@ class Trading(Link):
             # If I have a current open position in the opposite direction, double the order size
             multiplier = 1
             if(self.VENUES[venue][sym]['current_risk'] >= 0):
-              multiplier = self.MULTIPLIER
+              multiplier = self.VENUES[venue][sym].get('multiplier', 1)
             if(self.VENUES[venue][sym]['direction'] == 'LONG'):
               execInst = 'ParticipateDoNotInitiate,ReduceOnly'
             else:

--- a/src/grid-bots/multi-vendor-multi-contract.py
+++ b/src/grid-bots/multi-vendor-multi-contract.py
@@ -168,7 +168,6 @@ class Trading(Link):
         candles = self.fetch_candles(self.MAIN_VENUE, sym, level=self.LEVEL)
         self.VENUES[venue][sym]['candles'] = {x['time']: x['close'] for x in candles['data']} | self.VENUES[venue][sym]['candles']
 
-    self.fetch_current_risk()
     self.INIT_COMPLETE = True
     asyncio.run(self.minutely_update())
 


### PR DESCRIPTION
- Started to migrate some config from MACD bot
- Simplified required config in VENUES
- Executing fetch only once and start, and using events to update risk and orders
- Added orders tracking support
- Reduced candles in memory to 10 times LOOKBACK to avoid out of memory on long runnin bots
- Added support for API subaccounts
- Implemented order management
- Not creating new orders that would be cancelled with ReduceOnly
- Created a generic place_orders for bids/asks
- Removed VENUE_IDS
- Added Richard code for google sheet
- Added Top of Book mode
- Fixed INIT state
- Added retry for all call_endpoint